### PR TITLE
Delay added

### DIFF
--- a/src/Protocol.cpp
+++ b/src/Protocol.cpp
@@ -35,6 +35,7 @@ void OnDataSent(const uint8_t* mac_addr, esp_now_send_status_t status){
 void SendDiscoveryPacket(const uint8_t* broadcastAddress){
   DiscoveryPacket dsk_pkt;
   sendPacket(broadcastAddress, dsk_pkt);
+  delay(DIS_BROADCAST_SPEED);
 }
 
 void sendPacket(const uint8_t* mac_addr, const Packet& packet){


### PR DESCRIPTION
This pull request makes a minor update to the `SendDiscoveryPacket` function in `Protocol.cpp` to introduce a delay after sending a discovery packet. This change helps control the broadcast speed and may prevent network congestion or packet collisions.